### PR TITLE
CLIパッケージ化のための改良

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ jwcrypto/
 private_key.json
 public_key.json
 build
+__pycache__/

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,14 @@
 from distutils.core import setup
 from setuptools import setup, find_packages
-setup(packages=find_packages())
+setup(
+        install_requires=[
+            "jwcrypto>=1.0"
+            ],
+        entry_points={
+            "console_scripts":[
+                "genjwtkey=genjwtkey.generate:generate"
+                ]
+            },
+        packages=find_packages()
+        )
+


### PR DESCRIPTION
# 変更
```
python -m genjwtkey
```
から
```
genjwtkey
```
 で実行できるように変更。
また、インストール時に最低限必要な**jwcrypto**が一緒にインストールされるように変更。

# 動作チェック
なお、動作確認は以下の手順で行えるはず。
## インストール
```
sudo python setup.py develop
```
## 実行
```
~/.pyenv/versions/3.8.0/bin/genjwtkey
```
# 配布用パッケージ作成してから実行
配布用パッケージを作成し、pipからインストールすると`genjwtkey`で実行できる。
## 配布用パッケージの作成
いつもの要領で
```
python setup.py sdist
```
## インストール
```
pip install --find-links dist dist/genjwtkey-1.0.tar.gz
```
## 実行
```
genjwtkey
```